### PR TITLE
Allow blocks on Faraday connections

### DIFF
--- a/lib/faraday_bang/bang.rb
+++ b/lib/faraday_bang/bang.rb
@@ -1,22 +1,33 @@
 module Faraday::Bang
   ERROR_CODES = [(400..417).to_a, (500..505).to_a].flatten
+  SUPPORTED_HTTP_METHODS = Faraday::Connection::METHODS - Set.new([ :options ])
 
-  Faraday::Connection::METHODS.each do |verb|
+  SUPPORTED_HTTP_METHODS.each do |verb|
     define_method("#{verb}!") do |*args, &block|
       response = self.send(verb, *args, &block)
-      if response.status >= 400
-        err_name = "Response#{response.status}Error"
-        if Faraday::Bang.const_defined?(err_name)
-          klass = Faraday::Bang.const_get(err_name)
-          raise klass.new(response)
-        else
-          raise Faraday::Bang::ResponseError.new(response)
-        end
-      end
-      return response
+      handle_error(response)
     end
   end
 
+  define_method("options!") do |*args, &block|
+    url, params, headers = args
+    response = run_request(:options, url, params, headers, &block)
+    handle_error(response)
+  end
+
+  private
+  def handle_error(response)
+    if response.status >= 400
+      err_name = "Response#{response.status}Error"
+      if Faraday::Bang.const_defined?(err_name)
+        klass = Faraday::Bang.const_get(err_name)
+        raise klass.new(response)
+      else
+        raise Faraday::Bang::ResponseError.new(response)
+      end
+    end
+    response
+  end
 end
 
 Faraday.extend(Faraday::Bang)

--- a/lib/faraday_bang/bang.rb
+++ b/lib/faraday_bang/bang.rb
@@ -1,22 +1,22 @@
 module Faraday::Bang
   ERROR_CODES = [(400..417).to_a, (500..505).to_a].flatten
-  SUPPORTED_HTTP_METHODS = Faraday::Connection::METHODS - Set.new([ :options ])
+  SUPPORTED_HTTP_METHODS = Faraday::Connection::METHODS - [ :options ]
 
   SUPPORTED_HTTP_METHODS.each do |verb|
     define_method("#{verb}!") do |*args, &block|
       response = self.send(verb, *args, &block)
-      handle_error(response)
+      handle_response(response)
     end
   end
 
-  define_method("options!") do |*args, &block|
-    url, params, headers = args
-    response = run_request(:options, url, params, headers, &block)
-    handle_error(response)
+  def options!(*args, &block)
+    url, body, headers = args
+    response = run_request(:options, url, body, headers, &block)
+    handle_response(response)
   end
 
   private
-  def handle_error(response)
+  def handle_response(response)
     if response.status >= 400
       err_name = "Response#{response.status}Error"
       if Faraday::Bang.const_defined?(err_name)

--- a/lib/faraday_bang/bang.rb
+++ b/lib/faraday_bang/bang.rb
@@ -2,8 +2,8 @@ module Faraday::Bang
   ERROR_CODES = [(400..417).to_a, (500..505).to_a].flatten
 
   Faraday::Connection::METHODS.each do |verb|
-    define_method("#{verb}!") do |*args|
-      response = self.send(verb, *args)
+    define_method("#{verb}!") do |*args, &block|
+      response = self.send(verb, *args, &block)
       if response.status >= 400
         err_name = "Response#{response.status}Error"
         if Faraday::Bang.const_defined?(err_name)

--- a/test/lib/faraday_bang/bang_test.rb
+++ b/test/lib/faraday_bang/bang_test.rb
@@ -8,7 +8,14 @@ describe Faraday::Bang do
 
   [Faraday, Faraday.new].each do |klass|
 
-    Faraday::Connection::METHODS.each do |verb|
+    Faraday::Bang::SUPPORTED_HTTP_METHODS.each do |verb|
+
+      it "##{verb}! passes a block" do
+        block = Proc.new do |req|
+          raise "dummy error #{verb}"
+        end
+        ->{ klass.send("#{verb}!", &block) }.must_raise RuntimeError
+      end
 
       describe "##{verb}!" do
 

--- a/test/lib/faraday_bang/bang_test.rb
+++ b/test/lib/faraday_bang/bang_test.rb
@@ -7,6 +7,7 @@ describe Faraday::Bang do
   let(:body) { {foo: 'bar'}.to_json }
 
   [Faraday, Faraday.new].each do |klass|
+    let(:response) { mock(body: body, status: 200) }
 
     Faraday::Bang::SUPPORTED_HTTP_METHODS.each do |verb|
 
@@ -14,12 +15,11 @@ describe Faraday::Bang do
         block = Proc.new do |req|
           raise "dummy error #{verb}"
         end
-        ->{ klass.send("#{verb}!", &block) }.must_raise RuntimeError
+        error = ->{ klass.send("#{verb}!", &block) }.must_raise RuntimeError
+        error.message.must_equal "dummy error #{verb}"
       end
 
       describe "##{verb}!" do
-
-        let(:response) { mock(body: body, status: 200) }
 
         before do
           klass.expects(verb).with(url, args).returns(response)
@@ -61,6 +61,53 @@ describe Faraday::Bang do
 
       end
 
+    end
+
+    describe "options!" do
+      it "passes a block" do
+        block = Proc.new do |req|
+          raise "dummy error options"
+        end
+        error = ->{ klass.send("options!", &block) }.must_raise RuntimeError
+        error.message.must_equal "dummy error options"
+      end
+
+      describe 'successful response' do
+        before do
+          klass.expects(:run_request).with(:options, url, args, nil).returns(response)
+        end
+
+        it 'passes the call onto Faraday' do
+          res = klass.send("options!", url, args)
+          res.body.must_equal body
+        end
+      end
+
+      describe 'unsuccessful response' do
+        let(:env) { OpenStruct.new(url: 'http://example.com') }
+        let(:response) { OpenStruct.new(body: body, status: 506, env: env) }
+
+        before do
+          klass.expects(:run_request).with(:options, url, args, nil).returns(response)
+        end
+
+        it 'raises an error if its a non-200 response without an explicit exception' do
+          ->{klass.send("options!", url, args)}.must_raise Faraday::Bang::ResponseError, body
+        end
+
+        Faraday::Bang::ERROR_CODES.each do |code|
+
+          context code do
+
+            let(:response) { OpenStruct.new(body: body, status: code, env: env) }
+
+            it "raises a Faraday::Bang::Response#{code}Error" do
+              ->{klass.send("options!", url, args)}.must_raise Faraday::Bang.const_get("Response#{code}Error")
+            end
+
+          end
+        end
+      end
     end
 
   end


### PR DESCRIPTION
Hey Mark,

I'm adding the ability to use blocks when doing the requests. I have no idea on how to actually add a test for this, I've tried something like this but didn't work:

``` ruby
it 'passes a block' do
  block = Proc.new { |_, _| }
  klass.expects(verb).with(url, args, &block).returns(response)
  res = klass.send("#{verb}!", url, args, &block)
  res.body.must_equal body
end
```

It does however allow me to do something like this:

``` ruby
conn = Faraday.new(url: BASE_URL) do |builder|
  builder.request :url_encoded
  builder.adapter Faraday.default_adapter
end

conn.get! do |req|
  req.url url
  req.params = {foo: 'bar'}
  req.headers['Authorization'] = "Bearer #{access_token}"
  req.headers['Content-Type'] = 'application/json'
end
```

I'll gladly add tests if you can point me on how to do this.

Thanks!
